### PR TITLE
Use relative paths

### DIFF
--- a/parser/class.go
+++ b/parser/class.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/java"
+	"../java"
 )
 
 type ClassParser struct{}

--- a/parser/field.go
+++ b/parser/field.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alexeysoshin/smali2java/java"
-	"github.com/alexeysoshin/smali2java/smali"
+	"../java"
+	"../smali"
 )
 
 type FieldParser struct {

--- a/parser/if_eqz.go
+++ b/parser/if_eqz.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 	"strings"
 )
 

--- a/parser/implements.go
+++ b/parser/implements.go
@@ -1,6 +1,6 @@
 package parser
 
-import "github.com/alexeysoshin/smali2java/java"
+import "../java"
 
 type ImplementsParser struct{}
 

--- a/parser/int.go
+++ b/parser/int.go
@@ -2,8 +2,8 @@ package parser
 
 import (
 	"fmt"
-	"github.com/alexeysoshin/smali2java/java"
-	"github.com/alexeysoshin/smali2java/smali"
+	"../java"
+	"../smali"
 	"strconv"
 	"strings"
 )

--- a/parser/invoke_interface.go
+++ b/parser/invoke_interface.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 	"strings"
 )
 

--- a/parser/java_file.go
+++ b/parser/java_file.go
@@ -2,9 +2,9 @@ package parser
 
 import (
 	"fmt"
-	"github.com/alexeysoshin/smali2java/java"
-	"github.com/alexeysoshin/smali2java/java/types"
-	"github.com/alexeysoshin/smali2java/smali"
+	"../java"
+	"../java/types"
+	"../smali"
 	"strings"
 )
 

--- a/parser/method.go
+++ b/parser/method.go
@@ -2,8 +2,8 @@ package parser
 
 import (
 	"fmt"
-	"github.com/alexeysoshin/smali2java/java"
-	"github.com/alexeysoshin/smali2java/smali"
+	"../java"
+	"../smali"
 	"strings"
 )
 

--- a/parser/move_result.go
+++ b/parser/move_result.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 
 	"fmt"
 )

--- a/parser/return.go
+++ b/parser/return.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 
 	"fmt"
 )

--- a/parser/s_get.go
+++ b/parser/s_get.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 	"strings"
 )
 

--- a/parser/s_put.go
+++ b/parser/s_put.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 	"strings"
 )
 

--- a/parser/s_put_boolean.go
+++ b/parser/s_put_boolean.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/smali"
+	"../smali"
 	"strings"
 )
 

--- a/parser/super.go
+++ b/parser/super.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/alexeysoshin/smali2java/java"
-	"github.com/alexeysoshin/smali2java/java/classes"
+	"../java"
+	"../java/classes"
 )
 
 type SuperParser struct{}

--- a/smali2java.go
+++ b/smali2java.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"github.com/alexeysoshin/smali2java/parser"
+	"./parser"
 	"log"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Currently it doesn't allow to simply `go build` because it will fail due not finding those modules.
So use relative paths which allows to build easily.

Also I don't see any reason to not use relative paths.
