### PR TITLE
Handle const-string values with spaces in them

### DIFF
--- a/parser/final_string.go
+++ b/parser/final_string.go
@@ -7,7 +7,7 @@ type FinalStringParser struct{}
 func (p *FinalStringParser) Parse(javaFile *JavaFile, currentLine Line) error {
 	variableName := currentLine[1]
 	variableName = variableName[:len(variableName)-1]
-	variableValue := currentLine[2]
+	variableValue := strings.Join(currentLine[2:], " ")
 	line := []string{"final String", variableName, "=", variableValue, ";", "//", strings.Join(currentLine, " ")}
 	javaFile.AddLine(line)
 

--- a/parser/final_string_test.go
+++ b/parser/final_string_test.go
@@ -19,3 +19,17 @@ func TestFinalString(t *testing.T) {
 
 	assert.Equal(t, expectedOutput, output)
 }
+
+func TestFinalStringWithSpaces(t *testing.T) {
+	input := `const-string v0, "Hello, World!"`
+
+	javaFile := &JavaFile{}
+
+	(&FinalStringParser{}).Parse(javaFile, strings.Fields(input))
+
+	expectedOutput := `final String v0 = "Hello, World!" ; // const-string v0, "Hello, World!"`
+
+	output := strings.Join(javaFile.First(), " ")
+
+	assert.Equal(t, expectedOutput, output)
+}


### PR DESCRIPTION
I noticed the final string parser was giving bogus output when the string value had spaces in it (including not terminating the string properly). This is a simple fix to produce the correct output.