### PR TITLE
Support transient keyword

### DIFF
--- a/java/modifiers.go
+++ b/java/modifiers.go
@@ -3,6 +3,7 @@ package java
 var Modifiers = map[string]bool{"public": true, "private": true, "protected": true}
 
 const (
-	Final    = "final"
-	Volatile = "volatile"
+	Final     = "final"
+	Volatile  = "volatile"
+	Transient = "transient"
 )

--- a/parser/field.go
+++ b/parser/field.go
@@ -14,6 +14,7 @@ type FieldParser struct {
 	synthetic bool
 	final     bool
 	volatile  bool
+	transient bool
 }
 
 func (p *FieldParser) Parse(javaFile *JavaFile, currentLine Line) error {
@@ -55,11 +56,17 @@ func (p *FieldParser) Parse(javaFile *JavaFile, currentLine Line) error {
 		memberAndClassIndex++
 	}
 
+	if currentLine[memberAndClassIndex] == smali.Transient {
+		p.transient = true
+		memberAndClassIndex++
+	}
+
 	memberAndClass = strings.Split(currentLine[memberAndClassIndex], ":")
 
 	if len(memberAndClass) < 2 {
 		fmt.Println(currentLine)
 	}
+
 	className := GetClassName(memberAndClass[1])
 	memberName := memberAndClass[0]
 	var line []string
@@ -78,6 +85,10 @@ func (p *FieldParser) Parse(javaFile *JavaFile, currentLine Line) error {
 
 	if p.volatile {
 		line = append(line, java.Volatile)
+	}
+
+	if p.transient {
+		line = append(line, java.Transient)
 	}
 
 	line = append(line, className, memberName, ";")

--- a/smali/literals.go
+++ b/smali/literals.go
@@ -34,4 +34,5 @@ const (
 	IPutObject       = "iput-object"
 	IGetObject       = "iget-object"
 	Volatile         = "volatile"
+	Transient        = "transient"
 )


### PR DESCRIPTION
I think this resolves #14 but not sure given that I don't have the input for that.

However I saw similar errors popping up processing some smali files and found that the parser did not handle the `volatile` keyword.